### PR TITLE
Fixes #2. Update to match actual proposed semantics: Array.from() and Array.of()

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -33,7 +33,7 @@
   var sign = function(n) {
     return (n < 0) ? -1 : 1;
   };
-  
+
   var unique = function(iterable) {
     return Array.from(Set.from(iterable));
   };
@@ -64,15 +64,33 @@
   });
 
   // http://wiki.ecmascript.org/doku.php?id=strawman:array_extras
+  // Based on spec proposal production semantics defined by https://gist.github.com/1074126
   defineProperties(Array, {
-    of: function(iterable) {
-      return Array.prototype.slice.call(iterable);
+    from: function(iterable) {
+      var O = Object(iterable);
+      var len = O.length >>> 0;
+      var A = new Array();
+      var k = 0;
+
+      while( k < len ) {
+        var kValue;
+
+        if ( k in O ) {
+          kValue = O[ k ];
+          A[ k ] = kValue;
+        }
+        k++;
+      }
+      return A;
+    },
+    of: function() {
+      return Array.prototype.slice.call(arguments, 0);
     }
   });
 
   defineProperties(Number, {
     isInteger: function(value) {
-      return typeof value === 'number' && global_isFinite(value) && 
+      return typeof value === 'number' && global_isFinite(value) &&
         value > -9007199254740992 && value < 9007199254740992 &&
         Math.floor(value) === value;
     },
@@ -132,7 +150,7 @@
       return x !== x && y !== y;
     }
   });
-  
+
   defineProperties(Math, {
     sign: function(value) {
       var number = +value;
@@ -213,7 +231,7 @@
       // TODO: iteration.
     })()
   });
-  
+
   defineProperties(globall.Set, {
     of: function(iterable) {
       var object = Object(iterable);

--- a/test/array.js
+++ b/test/array.js
@@ -4,18 +4,31 @@ require('../');
 describe('Array', function() {
   describe('Array.of()', function() {
     it('should create correct array from iterable', function() {
+      expect(Array.of(0, 1, 2)).to.eql([0, 1, 2]);
+      expect(Array.of(null, undefined, 0.1248, -0, 0)).to.eql([null, undefined, 0.1248, -0, 0]);
+    });
+
+    it('should handle empty iterables correctly', function() {
       (function() {
-        expect(Array.of(arguments)).to.eql([0, 1, 2])
+        expect(Array.of()).to.eql([]);
+      })();
+    });
+  });
+
+  describe('Array.from()', function() {
+    it('should create correct array from iterable', function() {
+      (function() {
+        expect(Array.from(arguments)).to.eql([0, 1, 2])
       })(0, 1, 2);
-      
+
       (function() {
-        expect(Array.of(arguments)).to.eql([null, undefined, 0.1248, -0, 0]);
+        expect(Array.from(arguments)).to.eql([null, undefined, 0.1248, -0, 0]);
       })(null, undefined, 0.1248, -0, 0);
     });
 
     it('should handle empty iterables correctly', function() {
       (function() {
-        expect(Array.of(arguments)).to.eql([]);
+        expect(Array.from(arguments)).to.eql([]);
       })();
     });
   });


### PR DESCRIPTION
Updates tests, here is output:

```
./node_modules/mocha/bin/mocha --reporter spec


  Array
    Array.of()
      ✓ should create correct array from iterable 
      ✓ should handle empty iterables correctly 
    Array.from()
      ✓ should create correct array from iterable 
      ✓ should handle empty iterables correctly 

  Map
    ✓ should exist in global namespace 
    ✓ should return true on values that set has 
    ✓ should return true on values that set has not 
    ✓ should delete props 

  Math
    Math.sign()
      ✓ should be 1 on positive values 
      ✓ should be -1 on negative values 
      ✓ should be 0 on 0 
      ✓ should be NaN on NaN 

  Number
    Number.isInteger
      ✓ should be truthy on integers 
      ✓ should not be truthy on non-integers 
    Number.isNaN
      ◦ should be truthy on NaN: [Function]
      ✓ should be truthy on NaN 
      ✓ should be falsy on everything else 
    Number.toInteger
      ✓  
      ✓  

  Object
    Object.is
      ✓ should compare regular objects correctly 
      ✓ should compare 0 and -0 correctly 
      ✓ should compare NaNs correctly 
    #getOwnPropertyDescriptors
      ✓  
    #getPropertyDescriptor
      ✓  
    #getPropertyNames
      ✓  

  Set
    ✓ should exist in global namespace 
    ✓ should return true on values that set has 
    ✓ should return true on values that set has not 
    ✓ should delete props 

  String
    #repeat
      ✓ should work 
    #startsWith
      ✓ should be truthy on correct results 
      ✓ should be falsy on incorrect results 
    #endsWith
      ✓ should be truthy on correct results 
      ✓ should be falsy on incorrect results 
    #contains
      ✓ should be truthy on correct results 
      ✓ should be falsy on incorrect results 
    #toArray
      ✓ should be truthy on correct results 
      ✓ should be falsy on incorrect results 


  ✔ 37 tests complete (83ms)

```
