### PR TITLE
Updated README - Array.prototype, find() and findIndex() lines added to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ For node.js:
 * `Array`:
     * `from()`
     * `of()`
+* `Array.prototype`:
+    * `find()`
+    * `findIndex()`
 * `Object`:
     * `getOwnPropertyDescriptors()` (ES5)
     * `getPropertyDescriptor()` (ES5)


### PR DESCRIPTION
I've done the following additions to README.md
- `Array.prototype`:
  - `find()`
  - `findIndex()`
