### PR TITLE
Shorthand method access. Related: #75, #76

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -77,7 +77,7 @@ var main = function() {
 
     raw: function() {
       var callSite = arguments[0];
-      var substitutions = _slice.call(arguments, 1);
+      var substitutions = arraySlice.call(arguments, 1);
       var cooked = Object(callSite);
       var rawValue = cooked.raw;
       var raw = Object(rawValue);
@@ -134,7 +134,7 @@ var main = function() {
       var start = Math.min(Math.max(pos, 0), len);
       var searchLength = searchString.length;
       if ((searchLength + start) > len) return false;
-      var index = _indexOf.call(s, searchString, start);
+      var index = stringIndexOf.call(s, searchString, start);
       return index === start;
     },
 
@@ -149,7 +149,7 @@ var main = function() {
       var searchLength = searchString.length;
       var start = end - searchLength;
       if (start < 0) return false;
-      var index = _indexOf.call(s, searchString, start);
+      var index = stringIndexOf.call(s, searchString, start);
       return index === start;
     },
 
@@ -157,7 +157,7 @@ var main = function() {
       var position = arguments[1];
 
       // Somehow this trick makes method 100% compat with the spec.
-      return _indexOf.call(this, searchString, position) !== -1;
+      return stringIndexOf.call(this, searchString, position) !== -1;
     },
 
     codePointAt: function(pos) {


### PR DESCRIPTION
It's smart to cache the methods, but I would still use the shorthand way to access them. jQuery [does the same thing](https://github.com/jquery/jquery/blob/master/src/core.js#L27). It's surely not much slower and it only has to be done once since they are cached. Also, arrays have an `indexOf` method and strings have a `slice` method so I renamed the variables to be more specific:

So instead of this:

```
  var _slice = Array.prototype.slice;
  var _indexOf = String.prototype.indexOf;
```

It would be this:

```
  var arraySlice = [].slice;
  var stringIndexOf = ''.indexOf;
```
