### PR TITLE
Wrap everything in a self-invoking anonymous function

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -4,7 +4,7 @@
 // https://github.com/paulmillr/es6-shim/
 
 (function (undefined) {
-  function arePropertyDescriptorsSupported() {
+  var arePropertyDescriptorsSupported = function() {
     var attempt = function () {
       Object.defineProperty({}, 'x', {});
       return true;


### PR DESCRIPTION
1. Wrap everything in a self-invoking anonymous function so we don't pollute the global scope with variables like `main`
2. Use a function declaration instead of a function expression for the `arePropertyDescriptorsSupported` function
3. Cache `undefined` so it gets renamed to something shorter when compressed
