### PR TITLE
Math.roundFloat32

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -821,7 +821,7 @@
         return ((al * bl) + (((ah * bl + al * bh) << 16) >>> 0)|0);
       },
 
-      roundFloat32: function(x) {
+      fround: function(x) {
         if (x === 0 || x === Infinity || x === -Infinity || Number.isNaN(x)) {
           return x;
         }

--- a/test/math.js
+++ b/test/math.js
@@ -318,55 +318,55 @@ describe('Math', function() {
     });
   });
 
-  describe('Math.roundFloat32', function() {
+  describe('Math.fround', function() {
     // Mozilla's reference tests: https://bug900125.bugzilla.mozilla.org/attachment.cgi?id=793163
     it('returns NaN for undefined', function() {
-      expect(Number.isNaN(Math.roundFloat32())).to.be.ok;
+      expect(Number.isNaN(Math.fround())).to.be.ok;
     });
 
     it('returns NaN for NaN', function() {
-      expect(Number.isNaN(Math.roundFloat32(NaN))).to.be.ok;
+      expect(Number.isNaN(Math.fround(NaN))).to.be.ok;
     });
 
     it('works for zeroes and infinities', function() {
-      expect(isPositiveZero(Math.roundFloat32(0))).to.be.ok;
-      expect(isNegativeZero(Math.roundFloat32(-0))).to.be.ok;
-      expect(Math.roundFloat32(Infinity)).to.equal(Infinity);
-      expect(Math.roundFloat32(-Infinity)).to.equal(-Infinity);
+      expect(isPositiveZero(Math.fround(0))).to.be.ok;
+      expect(isNegativeZero(Math.fround(-0))).to.be.ok;
+      expect(Math.fround(Infinity)).to.equal(Infinity);
+      expect(Math.fround(-Infinity)).to.equal(-Infinity);
     });
 
     it('returns infinity for large numbers', function() {
-      expect(Math.roundFloat32(1.7976931348623157e+308)).to.equal(Infinity);
-      expect(Math.roundFloat32(-1.7976931348623157e+308)).to.equal(-Infinity);
-      expect(Math.roundFloat32(3.4028235677973366e+38)).to.equal(Infinity);
+      expect(Math.fround(1.7976931348623157e+308)).to.equal(Infinity);
+      expect(Math.fround(-1.7976931348623157e+308)).to.equal(-Infinity);
+      expect(Math.fround(3.4028235677973366e+38)).to.equal(Infinity);
     });
 
     it('returns zero for really small numbers', function() {
       expect(Number.MIN_VALUE).to.equal(Math.pow(2, -1074)); // sanity check
-      expect(Math.roundFloat32(Number.MIN_VALUE)).to.equal(0);
-      expect(Math.roundFloat32(-Number.MIN_VALUE)).to.equal(0);
+      expect(Math.fround(Number.MIN_VALUE)).to.equal(0);
+      expect(Math.fround(-Number.MIN_VALUE)).to.equal(0);
     });
 
     it('rounds properly', function() {
-      expect(Math.roundFloat32(3)).to.equal(3);
-      expect(Math.roundFloat32(-3)).to.equal(-3);
+      expect(Math.fround(3)).to.equal(3);
+      expect(Math.fround(-3)).to.equal(-3);
     });
 
     it('rounds properly with the max float 32', function() {
       var maxFloat32 = 3.4028234663852886e+38;
-      expect(Math.roundFloat32(maxFloat32)).to.equal(maxFloat32);
-      expect(Math.roundFloat32(-maxFloat32)).to.equal(-maxFloat32);
-      expect(Math.roundFloat32(maxFloat32 + Math.pow(2, Math.pow(2, 8 - 1) - 1 - 23 - 2))).to.equal(maxFloat32); // round-nearest rounds down to maxFloat32
+      expect(Math.fround(maxFloat32)).to.equal(maxFloat32);
+      expect(Math.fround(-maxFloat32)).to.equal(-maxFloat32);
+      expect(Math.fround(maxFloat32 + Math.pow(2, Math.pow(2, 8 - 1) - 1 - 23 - 2))).to.equal(maxFloat32); // round-nearest rounds down to maxFloat32
     });
 
     it('rounds properly with the min float 32', function() {
       var minFloat32 = 1.401298464324817e-45;
-      expect(Math.roundFloat32(minFloat32)).to.equal(minFloat32);
-      expect(Math.roundFloat32(-minFloat32)).to.equal(-minFloat32);
-      expect(Math.roundFloat32(minFloat32 / 2)).to.equal(0);
-      expect(Math.roundFloat32(-minFloat32 / 2)).to.equal(0);
-      expect(Math.roundFloat32(minFloat32 / 2 + Math.pow(2, -202))).to.equal(minFloat32);
-      expect(Math.roundFloat32(-minFloat32 / 2 - Math.pow(2, -202))).to.equal(-minFloat32);
+      expect(Math.fround(minFloat32)).to.equal(minFloat32);
+      expect(Math.fround(-minFloat32)).to.equal(-minFloat32);
+      expect(Math.fround(minFloat32 / 2)).to.equal(0);
+      expect(Math.fround(-minFloat32 / 2)).to.equal(0);
+      expect(Math.fround(minFloat32 / 2 + Math.pow(2, -202))).to.equal(minFloat32);
+      expect(Math.fround(-minFloat32 / 2 - Math.pow(2, -202))).to.equal(-minFloat32);
     });
   });
 });


### PR DESCRIPTION
Adding Math.roundFloat32.

There's a good bit of code, from https://github.com/inexorabletash/polyfill/blob/master/typedarray.js#L172-L278 (with permission), to support proper number truncation in an environment without TypedArrays.

There's also a TypedArray solution that will be much faster in newer environments.
