### PR TITLE
Further performance improvements to Map/Set

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -654,6 +654,11 @@
         return null;
       };
 
+      var emptyObject = function emptyObject() {
+        // accomodate some older not-quite-ES5 browsers
+        return Object.create ? Object.create(null) : {};
+      };
+
       var collectionShims = {
         Map: (function() {
 
@@ -706,7 +711,7 @@
 
             defineProperties(this, {
               '_head': head,
-              '_storage': Object.create(null),
+              '_storage': emptyObject(),
               '_size': 0
             });
           }
@@ -805,7 +810,7 @@
 
             clear: function() {
               this._size = 0;
-              this._storage = Object.create(null);
+              this._storage = emptyObject();
               var head = this._head, i = head, p = i.next;
               while ((i = p) !== head) {
                 i.key = i.value = empty;
@@ -852,7 +857,7 @@
             if (!(this instanceof SetShim)) throw new TypeError('Set must be called with "new"');
             defineProperties(this, {
               '[[SetData]]': null,
-              '_storage': Object.create(null)
+              '_storage': emptyObject()
             });
           };
 
@@ -914,7 +919,7 @@
 
             clear: function() {
               if (this._storage) {
-                this._storage = Object.create(null);
+                this._storage = emptyObject();
                 return;
               }
               return this['[[SetData]]'].clear();

--- a/test/collections.js
+++ b/test/collections.js
@@ -99,6 +99,11 @@ describe('Collections', function() {
         });
         if (slowkeys) testMapping(-0, {});
         testMapping('', {});
+        // verify that properties of Object don't peek through.
+        ['hasOwnProperty', 'constructor', 'toString', 'isPrototypeOf',
+         '__proto__', '__parent__', '__count__'].forEach(function(key) {
+           testMapping(key, {});
+         });
       }
     });
 
@@ -341,6 +346,9 @@ describe('Collections', function() {
         });
         if (slowkeys) testSet(-0);
         testSet('');
+        // verify that properties of Object don't peek through.
+        ['hasOwnProperty', 'constructor', 'toString', 'isPrototypeOf',
+         '__proto__', '__parent__', '__count__'].forEach(testSet);
       }
     });
 


### PR DESCRIPTION
Provide O(1) performance for numeric keys (as well as string keys), and defer allocation of the backing Map for Set, which speeds up allocation of Sets in the common case.
