### PR TITLE
Update devDependencies (mocha, chai).

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "mocha": "~1.12.1",
-    "chai": "~1.7.2",
+    "mocha": "~1.13.0",
+    "chai": "~1.8.1",
     "es5-shim": "~2.1.0"
   }
 }
-

--- a/test/array.js
+++ b/test/array.js
@@ -101,9 +101,9 @@ describe('Array', function() {
       var args = (function () { return arguments; }(1, 2, 3));
       expect(Array.isArray(args)).not.to.be.ok;
       var argsClass = Object.prototype.toString.call(args);
-      expect(args).to.eql([1, 2, 3]);
+      expect(Array.prototype.slice.call(args)).to.eql([1, 2, 3]);
       Array.prototype.copyWithin.call(args, -2, 0);
-      expect(args).to.eql([1, 1, 2]);
+      expect(Array.prototype.slice.call(args)).to.eql([1, 1, 2]);
       expect(Object.prototype.toString.call(args)).to.equal(argsClass);
     });
   });


### PR DESCRIPTION
With chai 1.8, arguments are not longer deep equal to arrays.
See https://github.com/chaijs/deep-eql#rules
