### PR TITLE
Include stack when chai assertions fail.

### DIFF
--- a/test/browser-setup.js
+++ b/test/browser-setup.js
@@ -1,4 +1,5 @@
 if (typeof window !== 'undefined') {
+  chai.Assertion.includeStack = true;
   window.expect = chai.expect;
   mocha.setup('bdd');
 }

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -1,3 +1,7 @@
-expect = require('chai').expect;
+expect = (function() {
+  var chai = require('chai');
+  chai.Assertion.includeStack = true;
+  return chai.expect;
+})();
 require('../');
 

--- a/testling.html
+++ b/testling.html
@@ -7,7 +7,7 @@
   <script src="node_modules/chai/chai.js"></script>
   <script src="node_modules/es5-shim/es5-shim.min.js"></script>
   <script src="es6-shim.js"></script>
-  <script>window.expect=chai.expect; mocha.setup({ui:'bdd',reporter:'tap'});</script>
+  <script>chai.Assertion.includeStack=true; window.expect=chai.expect; mocha.setup({ui:'bdd',reporter:'tap'});</script>
   <script src="test/array.js"></script>
   <script src="test/collections.js"></script>
   <script src="test/math.js"></script>


### PR DESCRIPTION
This makes it much easier to debug testling failures, for which we have only the TAP output of the tests.
