### PR TITLE
Improve compatibility with Chrome 7-10.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -140,6 +140,7 @@
 
       startsWith: function(searchStr) {
         if (this == null) throw new TypeError("Cannot call method 'startsWith' of " + this);
+        if (this === globals) throw new TypeError("Invalid this arg in pre-strict mode browser");
         var thisStr = String(this);
         searchStr = String(searchStr);
         var start = Math.max(ES.toInteger(arguments[1]), 0);
@@ -148,6 +149,7 @@
 
       endsWith: function(searchStr) {
         if (this == null) throw new TypeError("Cannot call method 'endsWith' of " + this);
+        if (this === globals) throw new TypeError("Invalid this arg in pre-strict mode browser");
         var thisStr = String(this);
         searchStr = String(searchStr);
         var thisLen = thisStr.length;


### PR DESCRIPTION
Ancient Chrome versions, before strict mode, never pass null or undefined
as "this" to a method.  They pass the global object instead.  Add an
explicit check to String.startsWtih and String.endsWith so that we
throw the TypeError that our test suite expects.
