### PR TITLE
Chai uses Object.create() so needs es5-sham to be loaded first on IE9.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "testling": {
     "html": "testling.html",
     "browsers": [
-      "iexplore/6.0..latest",
+      "iexplore/9.0..latest",
       "firefox/10.0",
       "firefox/17.0",
       "firefox/22.0..latest",

--- a/test/index.html
+++ b/test/index.html
@@ -5,9 +5,11 @@
   <title>es6-shim tests</title>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
   <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+  <script src="../node_modules/es5-shim/es5-shim.js"></script>
+  <script src="../node_modules/es5-shim/es5-sham.js"></script>
   <script src="../node_modules/mocha/mocha.js"></script>
+  <!-- note that chai uses Object.create() so needs es5-sham to be loaded -->
   <script src="../node_modules/chai/chai.js"></script>
-  <script src="../node_modules/es5-shim/es5-shim.min.js"></script>
   <script src="../es6-shim.js"></script>
   <script src="browser-setup.js"></script>
   <script src="array.js"></script>

--- a/testling.html
+++ b/testling.html
@@ -3,9 +3,11 @@
 <head>
   <meta charset="utf-8">
   <title>es6-shim tests</title>
+  <script src="node_modules/es5-shim/es5-shim.js"></script>
+  <script src="node_modules/es5-shim/es5-sham.js"></script>
   <script src="node_modules/mocha/mocha.js"></script>
+  <!-- note that chai uses Object.create() so needs es5-sham to be loaded -->
   <script src="node_modules/chai/chai.js"></script>
-  <script src="node_modules/es5-shim/es5-shim.min.js"></script>
   <script src="es6-shim.js"></script>
   <script>chai.Assertion.includeStack=true; window.expect=chai.expect; mocha.setup({ui:'bdd',reporter:'tap'});</script>
   <script src="test/array.js"></script>


### PR DESCRIPTION
Chai doesn't work for IE <=8, but this should get us (closer to) working
on IE >= 9.  Removed IE <= 8 from testling config, since we will never
pass tests there unless/until we rewrite the tests to use something other
than chai.
