### PR TITLE
Make `String#repeat` throw when called on `undefined` or `null`

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -44,6 +44,13 @@
     };
 
     var ES = {
+      CheckObjectCoercible: function(x) {
+        if (x == null) { // `null` or `undefined`
+          throw TypeError();
+        }
+        return x;
+      },
+
       ToInt32: function(x) {
         return x >> 0;
       },
@@ -134,7 +141,7 @@
           if (times < 0 || times === Infinity) {
             throw new RangeError();
           }
-          return repeat(String(this), times);
+          return repeat(String(ES.CheckObjectCoercible(this)), times);
         };
       })(),
 

--- a/test/string.js
+++ b/test/string.js
@@ -4,6 +4,12 @@ describe('String', function() {
       expect(function negativeOne() { return 'test'.repeat(-1); }).to.throw(RangeError);
       expect(function infinite() { return 'test'.repeat(Infinity); }).to.throw(RangeError);
     });
+    it('should throw a TypeError when called on null or undefined', function() {
+      expect(function callOnUndefined() { return String.prototype.repeat.call(undefined); }).to.throw(TypeError);
+      expect(function callOnNull() { return String.prototype.repeat.call(null); }).to.throw(TypeError);
+      expect(function callOnUndefined() { return String.prototype.repeat.apply(undefined); }).to.throw(TypeError);
+      expect(function callOnNull() { return String.prototype.repeat.apply(null); }).to.throw(TypeError);
+    });
     it('should coerce to an integer', function() {
       expect('test'.repeat(null)).to.eql('');
       expect('test'.repeat(false)).to.eql('');
@@ -334,7 +340,7 @@ describe('String', function() {
     });
 
     it('String.raw ReturnIfAbrupt - Less Substitutions', function() {
-      var callSite = {};  
+      var callSite = {};
       var str = 'The total is 10 ($';
       callSite.raw = {'0': "The total is ", '1': " ($", '2': " with tax)"};
       expect(String.raw(callSite,10)).to.eql(str);


### PR DESCRIPTION
Fixes #164.

(Now that it’s there, look into using `ES.checkObjectCoercible` more often — the spec uses it all the time. Ref. #166.)
