### PR TITLE
Make iterators compat with Firefox/Chrome; update ArrayIterator.

### DIFF
--- a/test/array.js
+++ b/test/array.js
@@ -215,7 +215,8 @@ var runArrayTests = function() {
         expect(Array.prototype.keys.length).to.equal(0);
       });
 
-      var keys = list.keys();
+      var mylist = [5, 10, 15, 20];
+      var keys = mylist.keys();
       it('should return 0 on first object', function() {
         expect(keys.next()).to.eql({value: 0, done: false});
       });
@@ -231,13 +232,18 @@ var runArrayTests = function() {
       it('should set done on completing iteration', function() {
         expect(keys.next()).to.eql({value: undefined, done: true});
       });
+      it('once done it should stay done', function() {
+        mylist.push(4);
+        expect(keys.next()).to.eql({value: undefined, done: true});
+      });
 
-      it('should skip sparse keys', function() {
+      it('should not skip sparse keys', function() {
         var sparse = [1];
-        sparse[3] = 4;
+        sparse[2] = 3;
         var keys = sparse.keys();
         expect(keys.next()).to.eql({value: 0, done: false});
-        expect(keys.next()).to.eql({value: 3, done: false});
+        expect(keys.next()).to.eql({value: 1, done: false});
+        expect(keys.next()).to.eql({value: 2, done: false});
         expect(keys.next()).to.eql({value: undefined, done: true});
       });
     });
@@ -247,7 +253,8 @@ var runArrayTests = function() {
         expect(Array.prototype.values.length).to.equal(0);
       });
 
-      var values = list.values();
+      var mylist = [5, 10, 15, 20];
+      var values = mylist.values();
       it('should return 5 on first object', function() {
         expect(values.next()).to.eql({value: 5, done: false});
       });
@@ -263,13 +270,18 @@ var runArrayTests = function() {
       it('should set done on completing iteration', function() {
         expect(values.next()).to.eql({value: undefined, done: true});
       });
+      it('once done it should stay done', function() {
+        mylist.push(4);
+        expect(values.next()).to.eql({value: undefined, done: true});
+      });
 
-      it('should skip sparse values', function() {
+      it('should not skip sparse values', function() {
         var sparse = [1];
-        sparse[3] = 4;
+        sparse[2] = 3;
         var values = sparse.values();
         expect(values.next()).to.eql({value: 1, done: false});
-        expect(values.next()).to.eql({value: 4, done: false});
+        expect(values.next()).to.eql({value: undefined, done: false});
+        expect(values.next()).to.eql({value: 3, done: false});
         expect(values.next()).to.eql({value: undefined, done: true});
       });
     });
@@ -279,7 +291,8 @@ var runArrayTests = function() {
         expect(Array.prototype.entries.length).to.equal(0);
       });
 
-      var entries = list.entries();
+      var mylist = [5, 10, 15, 20];
+      var entries = mylist.entries();
       it('should return [0, 5] on first object', function() {
         var val = entries.next();
         expect(val).to.eql({value: [0, 5], done: false});
@@ -300,13 +313,19 @@ var runArrayTests = function() {
         var val = entries.next();
         expect(val).to.eql({value: undefined, done: true});
       });
+      it('once done it should stay done', function() {
+        mylist.push(4);
+        var val = entries.next();
+        expect(val).to.eql({value: undefined, done: true});
+      });
 
-      it('should skip sparse entries', function() {
+      it('should not skip sparse entries', function() {
         var sparse = [1];
-        sparse[3] = 4;
+        sparse[2] = 3;
         var entries = sparse.entries();
         expect(entries.next()).to.eql({value: [0, 1], done: false});
-        expect(entries.next()).to.eql({value: [3, 4], done: false});
+        expect(entries.next()).to.eql({value: [1, undefined], done: false});
+        expect(entries.next()).to.eql({value: [2, 3], done: false});
         expect(entries.next()).to.eql({value: undefined, done: true});
       });
     });

--- a/test/collections.js
+++ b/test/collections.js
@@ -298,7 +298,7 @@ describe('Collections', function() {
     });
   });
 
-  it('iteration', function () {
+  it('map iteration', function () {
     var map = new Map();
     map.set('a', 1);
     map.set('b', 2);
@@ -315,6 +315,31 @@ describe('Collections', function() {
     keys.push(iterator.next().value);
     keys.push(iterator.next().value);
 
+    expect(iterator.next().done).to.equal(true);
+    map.set('f');
+    expect(iterator.next().done).to.equal(true);
+    expect(keys).to.eql(['a', 'd', 'e']);
+  });
+
+  it('set iteration', function () {
+    var set = new Set();
+    set.add('a');
+    set.add('b');
+    set.add('c');
+    set.add('d');
+
+    var keys = [];
+    var iterator = set.keys();
+    keys.push(iterator.next().value);
+    set["delete"]('a');
+    set["delete"]('b');
+    set["delete"]('c');
+    set.add('e');
+    keys.push(iterator.next().value);
+    keys.push(iterator.next().value);
+
+    expect(iterator.next().done).to.equal(true);
+    set.add('f');
     expect(iterator.next().done).to.equal(true);
     expect(keys).to.eql(['a', 'd', 'e']);
   });


### PR DESCRIPTION
ArrayIterator doesn't skip holes in the array anymore, according to the
latest es6 spec.  Fix our implementation.

Verify that an iterator can never be revived after it has returned 'done'.

Use `@@iterator` as a method name on Firefox for compatibility with its
partial implementation.  Add shims to the native iterators behind
`Array.values()` on Chrome (with harmony javascript enabled).  Add
shims to the native `MapIterator` and `SetIterator`, anticipating
that Chrome might eventually implement those as well.

Fixes: #189
