### PR TITLE
Array.from: Switching to pseudo-ES6 iterator protocol support (like in FF27)

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -63,11 +63,12 @@
     };
 
     // this is a private name in the es6 spec, equal to '[Symbol.iterator]'
-    // we're going to use an arbitrary __-prefixed name to make our shims
+    // we're going to use an '@@iterator' name to make our shims
     // work properly with each other, even though we don't have full Iterator
     // support.  That is, `Array.from(map.keys())` will work, but we don't
     // pretend to export a "real" Iterator interface.
-    var $iterator$ = '_@@iterator';
+    // FireFox 27+ also has '@@iterator' support see https://bugzilla.mozilla.org/show_bug.cgi?id=907077#c14
+    var $iterator$ = (typeof Symbol === 'object' && Symbol['iterator']) || '@@iterator';
     var addIterator = function(prototype, impl) {
       if (!impl) { impl = function iterator() { return this; }; }
       var o = {};


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=907077#c14

This will fix potential future incompatibility with FireFox
