### PR TITLE
Object.mixin() has been removed from the es6 spec.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -644,15 +644,6 @@
             target[key] = source[key];
             return target;
           }, target);
-        },
-
-        // 19.1.3.15
-        mixin: function(target, source) {
-          var props = Object.getOwnPropertyNames(source);
-          return props.reduce(function(target, property) {
-            var descriptor = Object.getOwnPropertyDescriptor(source, property);
-            return Object.defineProperty(target, property, descriptor);
-          }, target);
         }
       });
 

--- a/test/object.js
+++ b/test/object.js
@@ -65,12 +65,6 @@ describe('Object', function() {
     });
   });
 
-  describe('Object.mixin()', function() {
-    it('should merge descriptors of two objects', function() {
-      expect(Object.mixin({a: 1}, {b: 2})).to.eql({a: 1, b: 2});
-    });
-  });
-
   describe('Object.setPrototypeOf()', function() {
     describe('argument checking', function() {
       it('should throw TypeError if first arg is not object', function() {


### PR DESCRIPTION
Removed as of the Jan 20, 2014 es6 draft.

Closes #192.
