### PR TITLE
Map/Set should treat -0 and +0 as identical keys.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -101,6 +101,20 @@
         if (Number.isNaN(number)) return 0;
         if (number === 0 || !Number.isFinite(number)) return number;
         return Math.sign(number) * Math.floor(Math.abs(number));
+      },
+
+      SameValue: function(a, b) {
+        if (a === b) {
+          // 0 === -0, but they are not identical.
+          if (a === 0) return 1 / a === 1 / b;
+          return true;
+        }
+        return Number.isNaN(a) && Number.isNaN(b);
+      },
+
+      SameValueZero: function(a, b) {
+        // same as SameValue except for SameValueZero(+0, -0) == true
+        return (a === b) || (Number.isNaN(a) && Number.isNaN(b));
       }
     };
 
@@ -249,7 +263,7 @@
         var next;
         for (var i = 0, length = points.length; i < length; i++) {
           next = Number(points[i]);
-          if (!Object.is(next, ES.toInteger(next)) ||
+          if (!ES.SameValue(next, ES.toInteger(next)) ||
               next < 0 || next > 0x10FFFF) {
             throw new RangeError('Invalid code point ' + next);
           }
@@ -719,12 +733,7 @@
       },
 
       is: function(a, b) {
-        if (a === b) {
-          // 0 === -0, but they are not identical.
-          if (a === 0) return 1 / a === 1 / b;
-          return true;
-        }
-        return Number.isNaN(a) && Number.isNaN(b);
+        return ES.SameValue(a, b);
       }
     });
 
@@ -905,7 +914,7 @@
         var type = typeof key;
         if (type === 'string') {
           return '$' + key;
-        } else if (type === 'number' && !Object.is(key, -0)) {
+        } else if (type === 'number') {
           return key;
         }
         return null;
@@ -1005,7 +1014,7 @@
               }
               var head = this._head, i = head;
               while ((i = i.next) !== head) {
-                if (Object.is(i.key, key)) {
+                if (ES.SameValueZero(i.key, key)) {
                   return i.value;
                 }
               }
@@ -1020,7 +1029,7 @@
               }
               var head = this._head, i = head;
               while ((i = i.next) !== head) {
-                if (Object.is(i.key, key)) {
+                if (ES.SameValueZero(i.key, key)) {
                   return true;
                 }
               }
@@ -1042,7 +1051,7 @@
                 }
               }
               while ((i = i.next) !== head) {
-                if (Object.is(i.key, key)) {
+                if (ES.SameValueZero(i.key, key)) {
                   i.value = value;
                   return;
                 }
@@ -1068,7 +1077,7 @@
                 // fall through
               }
               while ((i = i.next) !== head) {
-                if (Object.is(i.key, key)) {
+                if (ES.SameValueZero(i.key, key)) {
                   i.key = i.value = empty;
                   i.prev.next = i.next;
                   i.next.prev = i.prev;

--- a/test/collections.js
+++ b/test/collections.js
@@ -74,12 +74,14 @@ describe('Collections', function() {
       expect(Map).to.throw(TypeError);
     });
 
-    it('treats positive and negative zero differently', function() {
+    it('treats positive and negative zero the same', function() {
       var value1 = {}, value2 = {};
-      testMapping(0, value1);
-      testMapping(-0, value2);
-      expect(map.get(0)).not.to.equal(value2);
-      expect(map.get(-0)).not.to.equal(value1);
+      testMapping(+0, value1);
+      expect(map.has(-0)).to.be.true;
+      expect(map.get(-0)).to.equal(value1);
+      map.set(-0, value2);
+      expect(map.get(-0)).to.equal(value2);
+      expect(map.get(+0)).to.equal(value2);
     });
 
     it('should map values correctly', function() {
@@ -97,12 +99,22 @@ describe('Collections', function() {
           if (slowkeys) testMapping(new String(number), {});
         });
 
-        [+0, NaN, Infinity, -Infinity, true, false, null, undefined].forEach(function(key) {
+        var testkeys = [+0, Infinity, -Infinity, NaN];
+        if (slowkeys) {
+          testkeys.push(true, false, null, undefined);
+        }
+        testkeys.forEach(function(key) {
           testMapping(key, {});
           testMapping('' + key, {});
         });
-        if (slowkeys) testMapping(-0, {});
         testMapping('', {});
+
+        // -0 and +0 should be the same key (Map uses SameValueZero)
+        expect(map.has(-0)).to.be.true;
+        map['delete'](+0);
+        testMapping(-0, {});
+        expect(map.has(+0)).to.be.true;
+
         // verify that properties of Object don't peek through.
         ['hasOwnProperty', 'constructor', 'toString', 'isPrototypeOf',
          '__proto__', '__parent__', '__count__'].forEach(function(key) {
@@ -404,12 +416,22 @@ describe('Collections', function() {
           if (slowkeys) testSet(new String(number));
         });
 
-        [+0, Infinity, -Infinity, true, false, null, undefined].forEach(function(number) {
+        var testkeys = [+0, Infinity, -Infinity, NaN];
+        if (slowkeys) {
+          testkeys.push(true, false, null, undefined);
+        }
+        testkeys.forEach(function(number) {
           testSet(number);
           testSet('' + number);
         });
-        if (slowkeys) testSet(-0);
         testSet('');
+
+        // -0 and +0 should be the same key (Set uses SameValueZero)
+        expect(set.has(-0)).to.be.true;
+        set['delete'](+0);
+        testSet(-0);
+        expect(set.has(+0)).to.be.true;
+
         // verify that properties of Object don't peek through.
         ['hasOwnProperty', 'constructor', 'toString', 'isPrototypeOf',
          '__proto__', '__parent__', '__count__'].forEach(testSet);


### PR DESCRIPTION
The latest spec (Jan 20, 2014) uses SameValueZero (not SameValue) for comparisons.  This is a change in the spec.

Closes: #129
