### PR TITLE
Don't use fast path after -0 is added to a Set.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -1180,7 +1180,11 @@
 
             add: function(key) {
               var fkey;
-              if (this._storage && (fkey = fastkey(key)) !== null) {
+              if (this._storage && (fkey = fastkey(key)) !== null &&
+                  // Force '-0' to use the slow path, since it will be
+                  // silently coerced to "0" when used as a property key
+                  // gh #202
+                  !(key === 0 && 1/key === -Infinity)) {
                 this._storage[fkey]=true;
                 return;
               }

--- a/test/collections.js
+++ b/test/collections.js
@@ -311,6 +311,22 @@ describe('Collections', function() {
         });
         expect(foundMap).to.eql(expectedMap);
       });
+
+      it('should store -0 as the key', function() {
+        var map = new Map(), result = [];
+        map.set(-0, 'a');
+        map.forEach(function(value, key) {
+          result.push(String(1/key) + ' ' + value);
+        });
+        map.set(1, 'b');
+        map.set(0, 'c');
+        map.forEach(function(value, key) {
+          result.push(String(1/key) + ' ' + value);
+        });
+        expect(result.join(', ')).to.equal(
+          "-Infinity a, -Infinity c, 1 b"
+        );
+      });
     });
   });
 
@@ -429,8 +445,12 @@ describe('Collections', function() {
         // -0 and +0 should be the same key (Set uses SameValueZero)
         expect(set.has(-0)).to.be.true;
         set['delete'](+0);
-        testSet(-0);
-        expect(set.has(+0)).to.be.true;
+        expect(set.has(-0)).to.be.false;
+        if (slowkeys) {
+          // adding -0 will cause the set to use the slower implementation
+          testSet(-0);
+          expect(set.has(+0)).to.be.true;
+        }
 
         // verify that properties of Object don't peek through.
         ['hasOwnProperty', 'constructor', 'toString', 'isPrototypeOf',
@@ -617,6 +637,22 @@ describe('Collections', function() {
           set['delete'](key);
         });
         expect(foundSet).to.eql(expectedSet);
+      });
+
+      it('should store -0 as the key', function() {
+        var set = new Set(), result = [];
+        set.add(-0);
+        set.forEach(function(key) {
+          result.push(String(1/key));
+        });
+        set.add(1);
+        set.add(0);
+        set.forEach(function(key) {
+          result.push(String(1/key));
+        });
+        expect(result.join(', ')).to.equal(
+          "-Infinity, -Infinity, 1"
+        );
       });
     });
 


### PR DESCRIPTION
The fast path for Set stores the set elements as properties of a backing
object.  But -0, when used as a property, gets coerced to "0" and the sign
is lost.  When we later `ensureMap` we end up using +0 as the key instead
of -0.

To avoid this error, force `ensureMap` before adding -0 to the set.  This
uses the slightly slower (but still O(1)) Map backing storage, which
properly preserves the sign of -0 when it is used as a key.

Closes #202.
