### PR TITLE
Fixed syntax errors reported by closure compiler

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -503,8 +503,8 @@
         var to = target < 0 ? Math.max(len + target, 0) : Math.min(target, len);
         var from = start < 0 ? Math.max(len + start, 0) : Math.min(start, len);
         var end = arguments.length > 2 ? arguments[2] : len;
-        var final = end < 0 ? Math.max(len + end, 0) : Math.min(end, len);
-        var count = Math.min(final - from, len - to);
+        var fin = end < 0 ? Math.max(len + end, 0) : Math.min(end, len);
+        var count = Math.min(fin - from, len - to);
         var direction = 1;
         if (from < to && to < (from + count)) {
           direction = -1;
@@ -610,7 +610,7 @@
         // isNaN is broken: it converts its argument to number, so
         // isNaN('foo') => true
         return value !== value;
-      },
+      }
 
     });
 


### PR DESCRIPTION
- "final" is a reserved word in in es>=3 (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Reserved_Words)
- Closure compiler does not like trailing commas in object literals. From the so discussion http://stackoverflow.com/questions/7246618/trailing-commas-in-javascript, It seems like trailing commas are allowed in es5, but ie<=8 and closure compiler don't not like them
