### PR TITLE
Fix Array#find and Array#findIndex on sparse arrays.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -610,9 +610,11 @@
           throw new TypeError('Array#find: predicate must be a function');
         }
         var thisArg = arguments[1];
-        for (var i = 0, value; i < length && i in list; i++) {
-          value = list[i];
-          if (predicate.call(thisArg, value, i, list)) return value;
+        for (var i = 0, value; i < length; i++) {
+          if (i in list) {
+            value = list[i];
+            if (predicate.call(thisArg, value, i, list)) return value;
+          }
         }
         return undefined;
       },
@@ -624,8 +626,10 @@
           throw new TypeError('Array#findIndex: predicate must be a function');
         }
         var thisArg = arguments[1];
-        for (var i = 0; i < length && i in list; i++) {
-          if (predicate.call(thisArg, list[i], i, list)) return i;
+        for (var i = 0; i < length; i++) {
+          if (i in list) {
+            if (predicate.call(thisArg, list[i], i, list)) return i;
+          }
         }
         return -1;
       },

--- a/test/array.js
+++ b/test/array.js
@@ -157,6 +157,36 @@ var runArrayTests = function() {
         var found = Array.prototype.find.call(obj, function(item) { return item === 2; });
         expect(found).to.equal(2);
       });
+
+      it('should work with an array-like object with negative length', function() {
+        var obj = { '0': 1, '1': 2, '2': 3, length: -3 };
+        var found = Array.prototype.find.call(obj, function(item) {
+          throw new Error('should not reach here');
+        });
+        expect(found).to.equal(undefined);
+      });
+
+      it('should work with a sparse array', function() {
+        var obj = [1,,undefined];
+        var seen = [];
+        var found = Array.prototype.find.call(obj, function(item, idx) {
+          seen.push([idx, item]);
+          return false;
+        });
+        expect(found).to.equal(undefined);
+        expect(seen).to.eql([[0,1],[2,undefined]]);
+      });
+
+      it('should work with a sparse array-like object', function() {
+        var obj = { '0': 1, '2': undefined, length: 3.2 };
+        var seen = [];
+        var found = Array.prototype.find.call(obj, function(item, idx) {
+          seen.push([idx, item]);
+          return false;
+        });
+        expect(found).to.equal(undefined);
+        expect(seen).to.eql([[0,1],[2,undefined]]);
+      });
     });
 
     describe('Array#findIndex', function() {
@@ -196,6 +226,36 @@ var runArrayTests = function() {
         var obj = { '0': 1, '1': 2, '2': 3, length: 3 };
         var foundIndex = Array.prototype.findIndex.call(obj, function(item) { return item === 2; });
         expect(foundIndex).to.equal(1);
+      });
+
+      it('should work with an array-like object with negative length', function() {
+        var obj = { '0': 1, '1': 2, '2': 3, length: -3 };
+        var foundIndex = Array.prototype.findIndex.call(obj, function(item) {
+          throw new Error('should not reach here');
+        });
+        expect(foundIndex).to.equal(-1);
+      });
+
+      it('should work with a sparse array', function() {
+        var obj = [1,,undefined];
+        var seen = [];
+        var foundIndex = Array.prototype.findIndex.call(obj, function(item, idx) {
+          seen.push([idx, item]);
+          return item === undefined;
+        });
+        expect(foundIndex).to.equal(2);
+        expect(seen).to.eql([[0,1],[2,undefined]]);
+      });
+
+      it('should work with a sparse array-like object', function() {
+        var obj = { '0': 1, '2': undefined, length: 3.2 };
+        var seen = [];
+        var foundIndex = Array.prototype.findIndex.call(obj, function(item, idx) {
+          seen.push([idx, item]);
+          return false;
+        });
+        expect(foundIndex).to.equal(-1);
+        expect(seen).to.eql([[0,1],[2,undefined]]);
       });
     });
 


### PR DESCRIPTION
The Array#find and Array#findIndex methods should skip elements which are
not present in the array-like object, but not terminate the search.
Audited against Jan 20, 2014 ES6 draft.
