### PR TITLE
Add jshint to `npm test` to keep code clean.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -67,7 +67,7 @@
     // work properly with each other, even though we don't have full Iterator
     // support.  That is, `Array.from(map.keys())` will work, but we don't
     // pretend to export a "real" Iterator interface.
-    var $iterator$ = (typeof Symbol === 'object' && Symbol['iterator']) ||
+    var $iterator$ = (typeof Symbol === 'object' && Symbol.iterator) ||
       '_es6shim_iterator_';
     // Firefox ships a partial implementation using the name @@iterator.
     // https://bugzilla.mozilla.org/show_bug.cgi?id=907077#c14
@@ -84,12 +84,14 @@
 
     var ES = {
       CheckObjectCoercible: function(x, optMessage) {
+        /* jshint eqnull:true */
         if (x == null)
           throw new TypeError(optMessage || ('Cannot call method on ' + x));
         return x;
       },
 
       TypeIsObject: function(x) {
+        /* jshint eqnull:true */
         // this is expensive when it returns false; use this function
         // when you expect it to return true in the common case.
         return x != null && Object(x) === x;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "es6-shim",
   "scripts": {
-    "test": "mocha test/*.js test/*/*.js"
+    "test": "jshint es6-shim.js && mocha test/*.js test/*/*.js"
   },
   "testling": {
     "html": "testling.html",
@@ -35,6 +35,7 @@
     "mocha": "~1.17.1",
     "chai": "~1.9.0",
     "es5-shim": "~2.3.0",
+    "jshint": "~2.4.3",
     "promises-aplus-tests": "~2.0.3"
   }
 }


### PR DESCRIPTION
Added two jshint annotations to allow `== null` in the places where we
explicitly want to test against null and undefined; add `jshint` to the
`npm test` command to keep our code clean.

This was suggested by @ljharb in #207.
