### PR TITLE
Rename Number.prototype.clz() to Math.clz32().

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -688,13 +688,6 @@
     });
 
     defineProperties(Number.prototype, {
-      clz: function() {
-        var number = ES.ToUint32(Number.prototype.valueOf.call(this));
-        if (number === 0) {
-          return 32;
-        }
-        return 32 - (number).toString(2).length;
-      }
     });
 
     if (supportsDescriptors) {
@@ -844,6 +837,17 @@
         if (negate) value = -value;
         result = Math.pow(value, 1/3);
         return negate ? -result : result;
+      },
+
+      clz32: function(value) {
+        // See https://bugs.ecmascript.org/show_bug.cgi?id=2465
+        value = Number(value);
+        if (Number.isNaN(value)) return NaN;
+        var number = ES.ToUint32(value);
+        if (number === 0) {
+          return 32;
+        }
+        return 32 - (number).toString(2).length;
       },
 
       cosh: function(value) {

--- a/test/math.js
+++ b/test/math.js
@@ -85,6 +85,44 @@ describe('Math', function() {
     });
   });
 
+  describe('.clz32()', function() {
+    it('should have proper uint32 conversion', function() {
+      var integers = [5295, -5295, -9007199254740991, 9007199254740991, 0, -0];
+      var infinities = [Infinity, -Infinity];
+      var nonNumbers = [undefined, true, null, {}, [], 'str'];
+      var nonIntegers = [-9007199254741992, 9007199254741992, 5.9];
+
+      infinities.forEach(function(item) {
+        expect(Math.clz32(item)).to.equal(32);
+      });
+      integers.forEach(function(item) {
+        expect(Math.clz32(item)).to.be.within(0, 32);
+      });
+      nonIntegers.forEach(function(item) {
+        expect(Math.clz32(item)).to.be.within(0, 32);
+      });
+      expect(Number.isNaN(Math.clz32(undefined))).to.be.ok;
+      expect(Math.clz32(null)).to.equal(Math.clz32(0));
+      expect(Math.clz32(false)).to.equal(Math.clz32(0));
+      expect(Math.clz32(true)).to.equal(Math.clz32(1));
+      expect(Math.clz32('')).to.equal(Math.clz32(0));
+      expect(Math.clz32('10')).to.equal(Math.clz32(10));
+      expect(Math.clz32([])).to.equal(Math.clz32(''));
+      expect(Number.isNaN(Math.clz32('str'))).to.be.ok;
+      expect(Number.isNaN(Math.clz32({}))).to.be.ok;
+      expect(Number.isNaN(Math.clz32(0/0))).to.be.ok;
+      expect(Math.clz32(0x100000000)).to.equal(32);
+      expect(Math.clz32(0.1)).to.equal(32);
+      expect(Math.clz32(-1)).to.equal(0);
+      expect(Math.clz32(0)).to.equal(32);
+      expect(Math.clz32(1)).to.equal(31);
+      expect(Math.clz32(0xFFFFFFFF)).to.equal(0);
+      expect(Math.clz32(0x1FFFFFFFF)).to.equal(0);
+      expect(Math.clz32(0x111111111)).to.equal(3);
+      expect(Math.clz32(0x11111111)).to.equal(3);
+    });
+  });
+
   describe('#cosh()', function() {
     it('should be correct for NaN', function() {
       expect(Number.isNaN(Math.cosh(NaN))).to.be.ok;

--- a/test/number.js
+++ b/test/number.js
@@ -220,27 +220,4 @@ describe('Number', function() {
       })).to.not.be.ok;
     });
   });
-
-  describe('#clz()', function() {
-    it('should have proper uint32 conversion', function() {
-      infinities.forEach(function(item) {
-        expect(item.clz()).to.equal(32);
-      });
-      nonIntegers.forEach(function(item) {
-        expect(item.clz()).to.be.within(0, 32);
-      });
-      nonNumbers.forEach(function(item) {
-        expect(function() { Number.prototype.clz.call(item) }).to.throw(TypeError);
-      });
-      expect(NaN.clz()).to.equal(32);
-      expect((0x100000000).clz()).to.equal(32);
-      expect((0.1).clz()).to.equal(32);
-      expect((-1).clz()).to.equal(0);
-      expect((0).clz()).to.equal(32);
-      expect((0xFFFFFFFF).clz()).to.equal(0);
-      expect((0x1FFFFFFFF).clz()).to.equal(0);
-      expect((0x111111111).clz()).to.equal(3);
-      expect((0x11111111).clz()).to.equal(3);
-    });
-  });
 });


### PR DESCRIPTION
This was decided in the Jan 28, 2014 ES6 meeting:
https://github.com/rwaldron/tc39-notes/blob/master/es6/2014-01/jan-28.md#clz-count-leading-zeros

There are some questions WRT the spec:
https://bugs.ecmascript.org/show_bug.cgi?id=2465
