### PR TITLE
Make sure Object.keys does not throw.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -839,7 +839,7 @@
     } catch (e) {
       var originalObjectKeys = Object.keys;
       Object.keys = function (obj) {
-        return originalObjectKeys(Object(obj));
+        return originalObjectKeys(ES.ToObject(obj));
       };
     }
 

--- a/test/object.js
+++ b/test/object.js
@@ -6,8 +6,14 @@ describe('Object', function() {
       expect(Object.keys('foo')).to.eql(['0', '1', '2']);
     });
 
+    it('throws on null or undefined', function() {
+      expect(function () { Object.keys(); }).to.throw(TypeError);
+      expect(function () { Object.keys(undefined); }).to.throw(TypeError);
+      expect(function () { Object.keys(null); }).to.throw(TypeError);
+    });
+
     it('works on other primitives', function() {
-      [true, false, undefined, NaN, 42, /a/g].forEach(function (item) {
+      [true, false, NaN, 42, /a/g].forEach(function (item) {
         expect(Object.keys(item)).to.eql([]);
       });
     });


### PR DESCRIPTION
Per https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.keys - Object.keys should now accept non-objects, and coerce them to objects.
