### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ For node.js:
 
 Math functions accuracy is 1e-11.
 
+## Subclassing
+The `Map`, `Set`, and `Promise` implementations are subclassable.
+You should use the following pattern to create a subclass in ES5 which
+will continue to work in ES6:
+```javascript
+function MyPromise(exec) {
+  Promise.call(this, exec);
+  // ...
+}
+Object.setPrototypeOf(MyPromise, Promise);
+MyPromise.prototype = Object.create(Promise.prototype, {
+  constructor: { value: MyPromise }
+});
+```
+
 ## String.prototype.normalize
 Including a proper shim for `String.prototype.normalize` would
 increase the size of this library by a factor of more than 4.

--- a/test/collections.js
+++ b/test/collections.js
@@ -86,9 +86,10 @@ describe('Collections', function() {
     it('should be subclassable', function() {
       var MyMap = function() { Map.call(this, [['a','b']]); }
       if (!MyMap.__proto__) { return; } // skip test if on IE < 11
-      MyMap.__proto__ = Map;
-      MyMap.prototype = Object.create(Map.prototype);
-      MyMap.prototype.constructor = MyMap;
+      Object.setPrototypeOf(MyMap, Map);
+      MyMap.prototype = Object.create(Map.prototype, {
+        constructor: { value: MyMap }
+      });
 
       map = new MyMap();
       testMapping('c', 'd');
@@ -440,9 +441,10 @@ describe('Collections', function() {
     it('should be subclassable', function() {
       var MySet = function() { Set.call(this, ['a', 'b']); }
       if (!MySet.__proto__) { return; } // skip test if on IE < 11
-      MySet.__proto__ = Set;
-      MySet.prototype = Object.create(Set.prototype);
-      MySet.prototype.constructor = MySet;
+      Object.setPrototypeOf(MySet, Set);
+      MySet.prototype = Object.create(Set.prototype, {
+        constructor: { value: MySet }
+      });
 
       set = new MySet();
       testSet('c'); testSet('d');

--- a/test/promise/all.js
+++ b/test/promise/all.js
@@ -176,9 +176,10 @@ describe("Promise.all", function () {
       }
     };
     if (!P.__proto__) { return done(); } // skip test if on IE < 11
-    P.__proto__ = Promise;
-    P.prototype = Object.create(Promise.prototype);
-    P.prototype.constructor = P;
+    Object.setPrototypeOf(P, Promise);
+    P.prototype = Object.create(Promise.prototype, {
+      constructor: { value: P }
+    });
     P.resolve = function(p) { return p; };
 
     var g = [

--- a/test/promise/evil-promises.js
+++ b/test/promise/evil-promises.js
@@ -9,9 +9,10 @@ describe("Evil promises should not be able to break invariants", function () {
     // Promise.resolve(evilPromise) is just the identity function.
     var EvilPromise = function(executor) { Promise.call(this, executor); };
     if (!EvilPromise.__proto__) { return; } // skip test if on IE < 11
-    EvilPromise.__proto__ = Promise; // mutable __proto__ is in es6.
-    EvilPromise.prototype = Object.create(Promise.prototype);
-    EvilPromise.prototype.constructor = EvilPromise;
+    Object.setPrototypeOf(EvilPromise, Promise);
+    EvilPromise.prototype = Object.create(Promise.prototype, {
+      constructor: { value: EvilPromise }
+    });
 
     var evilPromise = EvilPromise.resolve();
     evilPromise.then = function (f) {

--- a/test/promise/subclass.js
+++ b/test/promise/subclass.js
@@ -12,9 +12,10 @@ describe("Support user subclassing of Promise", function() {
       this.mine = 'yeah';
     };
     if (!MyPromise.__proto__) { return; } // skip test if on IE < 11
-    MyPromise.__proto__ = Promise; // mutable __proto__ is in es6.
-    MyPromise.prototype = Object.create(Promise.prototype);
-    MyPromise.prototype.constructor = MyPromise;
+    Object.setPrototypeOf(MyPromise, Promise);
+    MyPromise.prototype = Object.create(Promise.prototype, {
+      constructor: { value: MyPromise }
+    });
 
     // let's try it!
     var p1 = MyPromise.resolve(5);


### PR DESCRIPTION
Audit list of shimmed functions against source.
Add a note suggesting the use of `unorm` to shim `String.prototype.normalize`.
Update copyright year.
Describe how to use subclassing in ES5.
