### PR TITLE
Improve testling coverage.

### DIFF
--- a/test/object.js
+++ b/test/object.js
@@ -121,18 +121,24 @@ describe('Object', function() {
     });
 
     describe('set prototype', function() {
-      var Foo = function() {};
-      var Bar = {};
-      var foo = new Foo();
-      expect(Object.getPrototypeOf(foo)).to.equal(Foo.prototype);
+      it('should work', function() {
+        var Foo = function() {};
+        var Bar = {};
+        var foo = new Foo();
+        expect(Object.getPrototypeOf(foo)).to.equal(Foo.prototype);
 
-      var fooBar = Object.setPrototypeOf(foo, Bar);
-      expect(fooBar).to.equal(foo);
-      expect(Object.getPrototypeOf(foo)).to.equal(Bar);
+        var fooBar = Object.setPrototypeOf(foo, Bar);
+        expect(fooBar).to.equal(foo);
+        expect(Object.getPrototypeOf(foo)).to.equal(Bar);
+      });
+      it('should be able to set to null', function() {
+        var Foo = function() {};
+        var foo = new Foo();
 
-      var fooNull = Object.setPrototypeOf(foo, null);
-      expect(fooNull).to.equal(foo);
-      expect(Object.getPrototypeOf(foo)).to.equal(null);
+        var fooNull = Object.setPrototypeOf(foo, null);
+        expect(fooNull).to.equal(foo);
+        expect(Object.getPrototypeOf(foo)).to.equal(null);
+      });
     });
   });
 });

--- a/test/promise/all.js
+++ b/test/promise/all.js
@@ -1,7 +1,4 @@
 "use strict";
-require('../../'); // import Promise from es6-shim
-
-var assert = require("assert");
 
 var failIfThrows = function(done) {
   return function(e) { done(e); };

--- a/test/promise/evil-promises.js
+++ b/test/promise/evil-promises.js
@@ -1,7 +1,4 @@
 "use strict";
-require('../../'); // import Promise from es6-shim
-
-var assert = require("assert");
 
 describe("Evil promises should not be able to break invariants", function () {
   specify("resolving to a promise that calls onFulfilled twice", function (done) {

--- a/test/promise/promises-aplus.js
+++ b/test/promise/promises-aplus.js
@@ -1,6 +1,5 @@
 // tests from promises-aplus-tests
 "use strict";
-require('../../'); // import Promise from es6-shim
 
 describe("Promises/A+ Tests", function () {
   require("promises-aplus-tests").mocha({

--- a/test/promise/race.js
+++ b/test/promise/race.js
@@ -1,7 +1,4 @@
 "use strict";
-require('../../'); // import Promise from es6-shim
-
-var assert = require("assert");
 
 var delayPromise = function (value, ms) {
   return new Promise(function (resolve) {

--- a/test/promise/simple.js
+++ b/test/promise/simple.js
@@ -1,7 +1,4 @@
 "use strict";
-require('../../'); // import Promise from es6-shim
-
-var assert = require("assert");
 
 describe("Easy-to-debug sanity check", function () {
   specify("a fulfilled promise calls its fulfillment handler", function (done) {

--- a/test/promise/subclass.js
+++ b/test/promise/subclass.js
@@ -1,7 +1,4 @@
 "use strict";
-require('../../'); // import Promise from es6-shim
-
-var assert = require("assert");
 
 describe("Support user subclassing of Promise", function() {
   it("should work if you do it right", function() {

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -3,5 +3,10 @@ expect = (function() {
   chai.Assertion.includeStack = true;
   return chai.expect;
 })();
+assert = (function() {
+  var chai = require('chai');
+  chai.Assertion.includeStack = true;
+  return chai.assert;
+})();
 require('../');
 

--- a/testling.html
+++ b/testling.html
@@ -9,13 +9,21 @@
   <!-- note that chai uses Object.create() so needs es5-sham to be loaded -->
   <script src="node_modules/chai/chai.js"></script>
   <script src="es6-shim.js"></script>
-  <script>chai.Assertion.includeStack=true; window.expect=chai.expect; mocha.setup({ui:'bdd',reporter:'tap'});</script>
+  <script>chai.Assertion.includeStack=true; window.expect=chai.expect; window.assert=chai.assert; mocha.setup({ui:'bdd',reporter:'tap'});</script>
   <script src="test/array.js"></script>
   <script src="test/collections.js"></script>
   <script src="test/math.js"></script>
   <script src="test/number.js"></script>
   <script src="test/object.js"></script>
   <script src="test/string.js"></script>
+  <script src="test/promise/all.js"></script>
+  <script src="test/promise/evil-promises.js"></script>
+<!--
+  <script src="test/promise/promises-aplus.js"></script>
+-->
+  <script src="test/promise/race.js"></script>
+  <script src="test/promise/simple.js"></script>
+  <script src="test/promise/subclass.js"></script>
   <script>mocha.run()</script>
 </head>
 <body>


### PR DESCRIPTION
Fix a `Object.setPrototypeOf` test that was missing an `it` clause, leading
to confusing output on console (Opera 12, IE).

Add promises tests to `testling.html`; define `assert` in `test_helpers.js`.

Note that this reveals a number of issues with Chrome's built-in `Promise` implementation; a patch to shim in our implementation on Chrome is PR #224.
