### PR TITLE
Workaround Object.setPrototypeOf(..., null) bug in Opera.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -824,6 +824,25 @@
       });
     }
 
+    // Workaround bug in Opera 12 where setPrototypeOf(x, null) doesn't work,
+    // but Object.create(null) does.
+    if (Object.getPrototypeOf(Object.setPrototypeOf({}, null)) !== null &&
+        Object.getPrototypeOf(Object.create(null)) === null) {
+      (function() {
+        var FAKENULL = Object.create(null);
+        var gpo = Object.getPrototypeOf, spo = Object.setPrototypeOf;
+        Object.getPrototypeOf = function(o) {
+          var result = gpo(o);
+          return result === FAKENULL ? null : result;
+        };
+        Object.setPrototypeOf = function(o, p) {
+          if (p === null) { p = FAKENULL; }
+          return spo(o, p);
+        };
+        Object.setPrototypeOf.polyfill = false;
+      })();
+    }
+
     defineProperties(Object, {
       getOwnPropertyKeys: function(subject) {
         return Object.keys(subject);


### PR DESCRIPTION
We add an extra link to the prototype chain to workaround the issue.
