### PR TITLE
Adding extra OR condition to loading the shims.  This seems to fix ...

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -1822,6 +1822,7 @@
           typeof globals.Map.prototype.clear !== 'function' ||
           new globals.Set().size !== 0 ||
           new globals.Map().size !== 0 ||
+          typeof globals.Map.prototype.keys !== 'function' ||
           typeof globals.Set.prototype.keys !== 'function' ||
           typeof globals.Map.prototype.forEach !== 'function' ||
           typeof globals.Set.prototype.forEach !== 'function' ||


### PR DESCRIPTION
...a problem with the traceur runtime, and it kind of looks like the check on the Map's `keys` method was missed as an oversight, because there's a check on the Set prototype.

This helps some build issues existing in the angular/di.js repo.
