### PR TITLE
Fix issue for running under node-webkit.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -49,7 +49,7 @@
   };
 
   var main = function() {
-    var globals = (typeof global === 'undefined') ? self : global;
+    var globals = (typeof window !== 'undefined') ? window : global;
     var global_isFinite = globals.isFinite;
     var supportsDescriptors = !!Object.defineProperty && arePropertyDescriptorsSupported();
     var startsWithIsCompliant = startsWithRejectsRegex();
@@ -1436,7 +1436,7 @@
     });
     var promiseIgnoresNonFunctionThenCallbacks = (function () {
       try {
-        Promise.reject(42).then(null,5).then(null, function () {});
+        globals.Promise.reject(42).then(null,5).then(null, function () {});
         return true;
       } catch (ex) {
         return false;


### PR DESCRIPTION
Under node-webkit we have both contexts 'window' and 'global'.
'window' is default context then we should check for window first.
