### PR TITLE
A more reliable method to get the global object

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -48,8 +48,12 @@
     return rejectsRegex;
   };
 
+  /*jshint evil: true */
+  var getGlobal = new Function('return this;');
+  /*jshint evil: false */
+
   var main = function() {
-    var globals = (typeof global === 'undefined') ? self : global;
+    var globals = getGlobal();
     var global_isFinite = globals.isFinite;
     var supportsDescriptors = !!Object.defineProperty && arePropertyDescriptorsSupported();
     var startsWithIsCompliant = startsWithRejectsRegex();


### PR DESCRIPTION
Fixes #258.

This uses `eval` via the `Function` constructor, which is awful, but I can't come up with a better method in strict mode. I could also do `(function () { return this; }())` in non-strict mode, but then I'd have to make the outer wrapper of the shim not be in strict mode.
