### PR TITLE
Faster isInteger

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -755,9 +755,7 @@
       },
 
       isInteger: function(value) {
-        return typeof value === 'number' &&
-          !Number.isNaN(value) &&
-          Number.isFinite(value) &&
+        return Number.isFinite(value) &&
           ES.ToInteger(value) === value;
       },
 


### PR DESCRIPTION
`Number.isInteger` uses `Number.isFinite` internally, so there's no need to check typeof twice.
Native (global) `isFinite` used in `Number.isFinite` returns false is arg is `NaN`, so explicit `isNaN` check is redundant.
