### PR TITLE
Object: Remove Object.getOwnPropertyKeys

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -823,10 +823,6 @@
           });
         },
 
-        getOwnPropertyKeys: function(subject) {
-          return Object.keys(subject);
-        },
-
         is: function(a, b) {
           return ES.SameValue(a, b);
         },


### PR DESCRIPTION
In ES6 spec draft `getOwnPropertyKeys` is not exported as a property of `Object`. It is unused in other parts of project, so, I suppose, it can be removed.
