### PR TITLE
Make `String.fromCodePoint.length` equal to `1` as per the latest draft

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -388,7 +388,7 @@
     }());
 
     defineProperties(String, {
-      fromCodePoint: function() {
+      fromCodePoint: function(_) { // length = 1
         var points = _slice.call(arguments, 0, arguments.length);
         var result = [];
         var next;

--- a/test/string.js
+++ b/test/string.js
@@ -304,8 +304,8 @@ var runStringTests = function() {
         expect(String.fromCodePoint()).to.equal('');
       });
 
-      it('has a length of zero', function() {
-        expect(String.fromCodePoint.length).to.equal(0);
+      it('has a length of one', function() {
+        expect(String.fromCodePoint.length).to.equal(1);
       });
 
       it('works', function() {


### PR DESCRIPTION
I’m not sure when this changed exactly, but https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.fromcodepoint now says:

> The `length` property of the `fromCodePoint` function is `1`.
