### PR TITLE
Skip worker test when running via file URI scheme (Fix #272)

### DIFF
--- a/test/worker-test.js
+++ b/test/worker-test.js
@@ -12,9 +12,20 @@ describe('Worker', function() {
         errorText += ": " + errorEvent.message;
       }
       return new Error(errorText);
+    },
+    canRunWorkerTestInCurrentContext = function () {
+      var workerConstructorExists = typeof Worker !== 'undefined',
+        locationPropertyExists = typeof location !== 'undefined',
+        runningOnFileUriScheme = locationPropertyExists && location.protocol === 'file:';
+
+      // The Worker constructor doesn't exist in some older browsers nor does it exist in non-browser contexts like Node.
+      // Additionally some browsers (at least Chrome) don't allow Workers over file URIs.
+      // To prevent false negative test failures in the cases where Workers are unavailable for either of those reasons 
+      // we skip this test.
+      return workerConstructorExists && !runningOnFileUriScheme;
     };
 
-  if (typeof Worker !== 'undefined') {
+  if (canRunWorkerTestInCurrentContext()) {
     it('can import es6-shim', function (done) {
       var worker = new Worker('worker-runner.workerjs');
       worker.addEventListener('error', function (errorEvent) { throw workerErrorEventToError(errorEvent); });


### PR DESCRIPTION
I verified the tests pass with this modification in the latest Internet Explorer & Chrome and under Mocha.
