### PR TITLE
Detect and override Safari 7.1 native Promises

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -1498,7 +1498,11 @@
         return false;
       }
     }());
-    if (!promiseSupportsSubclassing || !promiseIgnoresNonFunctionThenCallbacks) {
+    var promiseRequiresObjectContext = (function () {
+      try { Promise.call(3, function () {}); } catch (e) { return true; }
+      return false;
+    }());
+    if (!promiseSupportsSubclassing || !promiseIgnoresNonFunctionThenCallbacks || !promiseRequiresObjectContext) {
       globals.Promise = PromiseShim;
     }
 


### PR DESCRIPTION
@cscott, what do you think? Would it be worth just wrapping Safari 7.1's native Promises rather than completely overriding them?

Fixes #288.
