### PR TITLE
Some JS engines don't preserve insertion order for numeric keys.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -1511,14 +1511,30 @@
     }
 
     // Map and Set require a true ES5 environment
+    // Their fast path also requires that the environment preserve
+    // property insertion order, which is not guaranteed by the spec.
+    var testOrder = function(a) {
+      var b = Object.keys(a.reduce(function(o, k) { o[k] = true; return o; }, {}));
+      return a.join(':') === b.join(':');
+    };
+    var preservesInsertionOrder = testOrder(['z','a','bb']);
+    // some engines (eg, Chrome) only preserve insertion order for string keys
+    var preservesNumericInsertionOrder = testOrder(['z',1,'a','3',2]);
+
     if (supportsDescriptors) {
 
       var fastkey = function fastkey(key) {
+        if (!preservesInsertionOrder) {
+          return null;
+        }
         var type = typeof key;
         if (type === 'string') {
           return '$' + key;
         } else if (type === 'number') {
           // note that -0 will get coerced to "0" when used as a property key
+          if (!preservesNumericInsertionOrder) {
+            return 'n' + key;
+          }
           return key;
         }
         return null;
@@ -1813,6 +1829,8 @@
                 // fast check for leading '$'
                 if (k.charCodeAt(0) === 36) {
                   k = k.slice(1);
+                } else if (k.charCodeAt(0) === 110 /* 'n' */) {
+                  k = +(k.slice(1));
                 } else {
                   k = +k;
                 }


### PR DESCRIPTION
Fixes #290.
