### PR TITLE
Simplify `getPropertyDescriptor`

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -922,12 +922,10 @@
   if (supportsDescriptors) {
     defineProperties(Object, {
       getPropertyDescriptor: function (subject, name) {
-        var pd = Object.getOwnPropertyDescriptor(subject, name);
-        var proto = Object.getPrototypeOf(subject);
-        while (typeof pd === 'undefined' && proto !== null) {
-          pd = Object.getOwnPropertyDescriptor(proto, name);
-          proto = Object.getPrototypeOf(proto);
-        }
+        var pd;
+        do {
+          pd = Object.getOwnPropertyDescriptor(subject, name);
+        } while (!pd && (subject = Object.getPrototypeOf(subject)));
         return pd;
       },
 


### PR DESCRIPTION
Do not try to get prototype if we already have descriptor.
