### PR TITLE
Make `RegExp.prototype.flags` more spec-compliant

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -1027,8 +1027,23 @@
       if (!ES.TypeIsObject(this)) {
         throw new TypeError('Method called on incompatible type: must be an object.');
       }
-      var str = String(this);
-      return str.slice(str.lastIndexOf('/') + 1);
+      var result = '';
+      if (this.global) {
+        result += 'g';
+      }
+      if (this.ignoreCase) {
+        result += 'i';
+      }
+      if (this.multiline) {
+        result += 'm';
+      }
+      if (this.unicode) {
+        result += 'u';
+      }
+      if (this.sticky) {
+        result += 'y';
+      }
+      return result;
     };
 
     Value.getter(RegExp.prototype, 'flags', regExpFlagsGetter);

--- a/test/regexp.js
+++ b/test/regexp.js
@@ -55,11 +55,23 @@ describe('RegExp', function () {
     });
   });
 
+  var regexpFlagsDescriptor = Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags');
+  var testGenericRegExpFlags = function (object) {
+    return regexpFlagsDescriptor.get.call(object);
+  };
+
   describe('#flags', function () {
+    it('has the correct descriptor', function () {
+      expect(regexpFlagsDescriptor.configurable).to.equal(true);
+      expect(regexpFlagsDescriptor.enumerable).to.equal(false);
+      expect(regexpFlagsDescriptor.get instanceof Function).to.equal(true);
+      expect(regexpFlagsDescriptor.set).to.equal(undefined);
+    });
+
     it('throws when not called on an object', function () {
       var nonObjects = ['', false, true, 42, NaN, null, undefined];
       nonObjects.forEach(function (nonObject) {
-        expect(function () { RegExp.prototype.flags.call(nonObject); }).to['throw'](TypeError);
+        expect(function () { testGenericRegExpFlags(nonObject); }).to['throw'](TypeError);
       });
     });
 


### PR DESCRIPTION
Note that this still isn’t fully spec-compliant, since it shouldn’t be configurable.
