### PR TITLE
Update `Promise.reject` to match official ECMA-262 spec.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -2000,7 +2000,7 @@
       },
 
       reject: function reject(reason) {
-        var C = getPromiseSpecies(this);
+        var C = this;
         var capability = new PromiseCapability(C);
         var rejectFunc = capability.reject;
         rejectFunc(reason); // call with this===undefined


### PR DESCRIPTION
There was a last-minute change to `Promise.reject` to make it better match `Promise.resolve`.  See:
http://www.ecma-international.org/ecma-262/6.0/#sec-promise.reject