### PR TITLE
Add missing checks to Promise.resolve and Promise.reject.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -2316,6 +2316,9 @@
 
       reject: function reject(reason) {
         var C = this;
+        if (!ES.TypeIsObject(C)) {
+          throw new TypeError('Bad promise constructor');
+        }
         var capability = new PromiseCapability(C);
         var rejectFunc = capability.reject;
         rejectFunc(reason); // call with this===undefined
@@ -2325,6 +2328,9 @@
       resolve: function resolve(v) {
         // See https://esdiscuss.org/topic/fixing-promise-resolve for spec
         var C = this;
+        if (!ES.TypeIsObject(C)) {
+          throw new TypeError('Bad promise constructor');
+        }
         if (ES.IsPromise(v)) {
           var constructor = v.constructor;
           if (constructor === C) { return v; }


### PR DESCRIPTION
These checks were overlooked when @@species was resolved from these methods.

Discovered by running the ES2015 test262 test suite against es6-shim.