### PR TITLE
Optimize Map/Set fast key path.

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -2631,18 +2631,17 @@
       if (!preservesInsertionOrder) {
         return null;
       }
-      var type = typeof key;
-      if (type === 'undefined' || key === null) {
+      if (typeof key === 'undefined' || key === null) {
         return '^' + ES.ToString(key);
-      } else if (type === 'string') {
+      } else if (typeof key === 'string') {
         return '$' + key;
-      } else if (type === 'number') {
+      } else if (typeof key === 'number') {
         // note that -0 will get coerced to "0" when used as a property key
         if (!preservesNumericInsertionOrder) {
           return 'n' + key;
         }
         return key;
-      } else if (type === 'boolean') {
+      } else if (typeof key === 'boolean') {
         return 'b' + key;
       }
       return null;


### PR DESCRIPTION
The expression `typeof x === 'some string'` is treated as a peephole
optimization by JavaScript runtimes and optimized as a simple type test
without an explicit string comparison.  Refactoring the `typeof x` part
into a variable cause this to be deoptimized: the type information
is lost and we end up doing actual string comparison operations at
runtime.