### PR TITLE
Remove special character and replace with regular apostrophe

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -79,7 +79,7 @@
   };
 
   // Define configurable, writable and non-enumerable props
-  // if they don’t exist.
+  // if they don't exist.
   var defineProperties = function (object, map, forceOverride) {
     _forEach(keys(map), function (name) {
       var method = map[name];


### PR DESCRIPTION
We have a build script which we are using but it doesn't accept special characters. I noticed it breaking on your project. The character was a `’` apostrophe and it's just in a comment. I have replaced that with a regular one.