### PR TITLE
Fix 'Uncaught (in promise) TypeError' in Chrome 48

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -2561,7 +2561,7 @@
       p.constructor = {};
       var p2 = Promise.resolve(p);
       try {
-        p2.then(null, function () {}); // avoid "uncaught rejection" warnings in console
+        p2.then(null, noop).then(null, noop); // avoid "uncaught rejection" warnings in console
       } catch (e) {
         return true; // v8 native Promises break here https://code.google.com/p/chromium/issues/detail?id=575314
       }


### PR DESCRIPTION
Fix for Issue #407.

On Chrome 48.0 in OSX, the following console warning started appearing with the release of es6-shim v0.34.3:

```
Uncaught (in promise) TypeError: object is not a function            index.html:1
    at Object.defer (native)
    at chain (native)
    at then (native)
```

The one-line change here fixes the warning. It seems that the warning was originating from the 'inner' promise `p` (the promise resolved by the 'outer' promise `p2`) on [line 2562](https://github.com/paulmillr/es6-shim/blob/5f641326fe41fa85ccadb373a7e8c56c0acd0e2f/es6-shim.js#L2562). The fix was to catch the rejection by promise `p` with a noop.

The warning is gone and all tests are passing.