### PR TITLE
Early exit from tanh for values >=20 <=-20 as JS loses precision

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -1957,8 +1957,9 @@
     tanh: function tanh(value) {
       var x = Number(value);
       if (Number.isNaN(x) || x === 0) { return x; }
-      if (x === Infinity) { return 1; }
-      if (x === -Infinity) { return -1; }
+      // can exit early at +-20 as JS loses precision for true value at this integer
+      if (x >= 20) { return 1; }
+      if (x <= -20) { return -1; }
       var a = Math.expm1(x);
       var b = Math.expm1(-x);
       if (a === Infinity) { return 1; }

--- a/test/math.js
+++ b/test/math.js
@@ -605,7 +605,10 @@ describe('Math', function () {
       expect(isNegativeZero(Math.tanh(-0))).to.equal(true);
       expect(Math.tanh(Infinity)).to.equal(1);
       expect(Math.tanh(-Infinity)).to.equal(-1);
-      expect(Math.tanh(90)).to.almostEqual(1);
+      expect(Math.tanh(19)).to.almostEqual(1);
+      expect(Math.tanh(-19)).to.almostEqual(-1);
+      expect(Math.tanh(20)).to.equal(1); // JS loses precision for true value at this integer
+      expect(Math.tanh(-20)).to.equal(-1); // JS loses precision for true value at this integer
       expect(Math.tanh(10)).to.almostEqual(0.9999999958776927);
       expect(Math.tanh(-2e-17)).to.equal(-2e-17);
     });


### PR DESCRIPTION
tanh tends to Infinity *very* quickly. See the calculations of tanh at the boundary integers of 19 and 20 below. The value is calculated via wolfram alpha then pasted into a JS console to check if JS can represent the value.

tanh(19)
https://www.wolframalpha.com/input/?i=tanh+19
result = 0.99999999999999993721734415903940939665164417761315093858
JS: 0.9999999999999999

tanh(20)
https://www.wolframalpha.com/input/?i=tanh+20
result = 0.999999999999999991503291489416822045438558191190987257130
JS: 1

As can be seen, tanh(20) is equal to 1. Since tanh(Infinity) is also equal to 1 we can treat anything >= 20 as 1.
tanh is an 'odd' function so the same applies to negative values.

Benefits of exiting early:
- speed improvement for a large range of input values
- slightly more accurate for a few values close to 20 (will be 1 instead of 0.999... as was previously being calculated).
- smaller source

Note: there are values between 19 and 20 that also round to 1 but the source should be kept clean at an integer value.