### PR TITLE
Drop node support for 0.4 to 0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,6 @@ node_js:
   - "iojs-v1.0"
   - "0.11"
   - "0.10"
-  - "0.9"
-  - "0.8"
-  - "0.6"
-  - "0.4"
 before_install:
   - 'if [ "${TRAVIS_NODE_VERSION}" != "0.9" ]; then case "$(npm --version)" in 1.*) npm install -g npm@1.4.28 ;; 2.*) npm install -g npm@2 ;; esac ; fi'
   - 'if [ "${TRAVIS_NODE_VERSION}" != "0.6" ] && [ "${TRAVIS_NODE_VERSION}" != "0.9" ]; then npm install -g npm; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,11 +93,8 @@ matrix:
     - node_js: "iojs-v1.2"
     - node_js: "iojs-v1.1"
     - node_js: "iojs-v1.0"
-    - node_js: "0.11"
-    - node_js: "0.9"
-    - node_js: "0.6"
-    - node_js: "0.4"
     - node_js: "0.12"
+    - node_js: "0.11"
       env: TRAVIS_RUN_SAUCE=true TRAVIS_RUN_LINT_ONLY=false
 env:
   global:


### PR DESCRIPTION
Reason since most users are on node 0.10 or above and even then usage of 0.10 is going down.