### PR TITLE
Don't mix formal parameters and arguments array

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -1387,7 +1387,8 @@
     var isBadHex = isBadHexRegex.test.bind(isBadHexRegex);
     var NumberShim = (function () {
       // this is wrapped in an IIFE because of IE 6-8's wacky scoping issues with named function expressions.
-      var NumberShim = function Number(value) {
+      var NumberShim = function Number() {
+        var value = arguments[0];
         var primValue;
         if (arguments.length > 0) {
           primValue = Type.primitive(value) ? value : toPrimitive(value, 'number');


### PR DESCRIPTION
IE11 perf is significantly degraded when mixing formal parameters and the arguments array

Perf comparisons of mixing formal parameters and arguments vs not shows not mixing is much faster. And using only formal parameters vs using only arguments array shows similar perf.
![mixed-perf](https://user-images.githubusercontent.com/47883805/75580576-e8d3cc00-5a1c-11ea-9fb2-607f951da545.png)
![unmixed-perf](https://user-images.githubusercontent.com/47883805/75580582-ea9d8f80-5a1c-11ea-88d3-acf1630515f0.png)
