### PR TITLE
Fix crash when `target`(in Value.preserveToString) is undefined

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -137,7 +137,7 @@
       }
     },
     preserveToString: function (target, source) {
-      if (source && isCallable(source.toString)) {
+      if (target && source && isCallable(source.toString)) {
         defineProperty(target, 'toString', source.toString.bind(source), true);
       }
     }


### PR DESCRIPTION
https://github.com/paulmillr/es6-shim/issues/467