### PR TITLE
Fix `ReflectShims.defineProperty` is undefined in WSH

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -1264,10 +1264,7 @@
   // Chrome defines keys/values/entries on Array, but doesn't give us
   // any way to identify its iterator.  So add our own shimmed field.
   if (Object.getPrototypeOf) {
-    var ChromeArrayIterator = Object.getPrototypeOf([].values());
-    if (ChromeArrayIterator) { // in WSH, this is `undefined`
-      addIterator(ChromeArrayIterator);
-    }
+    addIterator(Object.getPrototypeOf([].values());
   }
 
   // note: this is positioned here because it relies on Array#entries
@@ -3585,7 +3582,7 @@
     });
   }
 
-  if (supportsDescriptors) {
+  if (!ReflectShims.defineProperty) {    // possible alternative: if (supportsDescriptors)
     var internalGet = function get(target, key, receiver) {
       var desc = Object.getOwnPropertyDescriptor(target, key);
 


### PR DESCRIPTION
* Reverted from #466 - No need to check that this is `undefined`.
* This pull request fixes the following issue: #470 #467