### PR TITLE
[actions] restrict permissions

### DIFF
--- a/.github/workflows/node-aught.yml
+++ b/.github/workflows/node-aught.yml
@@ -2,6 +2,9 @@ name: 'Tests: node.js < 10'
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     uses: ljharb/actions/.github/workflows/node.yml@main

--- a/.github/workflows/node-pretest.yml
+++ b/.github/workflows/node-pretest.yml
@@ -2,6 +2,9 @@ name: 'Tests: pretest/posttest'
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     uses: ljharb/actions/.github/workflows/pretest.yml@main

--- a/.github/workflows/node-pretest.yml
+++ b/.github/workflows/node-pretest.yml
@@ -5,3 +5,5 @@ on: [pull_request, push]
 jobs:
   tests:
     uses: ljharb/actions/.github/workflows/pretest.yml@main
+    with:
+      skip-pack: true # `npm run tests-only` fails in node 15+ without NODE_OPTIONS=--unhandled-rejections=none, but older nodes throw for unrecognized NODE_OPTIONS

--- a/.github/workflows/node-tens.yml
+++ b/.github/workflows/node-tens.yml
@@ -2,6 +2,9 @@ name: 'Tests: node.js >= 10'
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     uses: ljharb/actions/.github/workflows/node.yml@main

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -2,8 +2,14 @@ name: Automatic Rebase
 
 on: [pull_request_target]
 
+permissions:
+  contents: read
+
 jobs:
   _:
+    permissions:
+      contents: write
+      pull-requests: read
     name: "Automatic Rebase"
 
     runs-on: ubuntu-latest

--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -2,8 +2,13 @@ name: Require “Allow Edits”
 
 on: [pull_request_target]
 
+permissions:
+  contents: read
+
 jobs:
   _:
+    permissions:
+      pull-requests: read
     name: "Require “Allow Edits”"
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi. I'd like to suggest some security enhancements. In this PR, I change the configurations of actions:
1. set up minimal permissions of actions
2. pinned the dependencies of actions
3. add dependabot for actions.

Here are the two corresponding security risks for each of them:
1. Permissions: Lack of explicit permission settings may allow a malicious PR to inject malicious code through write permissions in actions. Adding read-only permissions at the top level will help you avoid forgetting permission configurations when adding other jobs next time.
2. Pinned dependencies: There have been a related [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2025-30066) recently. It indicates that if the version of a dependent action is pinned to a malicious commit, it may lead to the execution of malicious scripts, potentially exposing secrets such as the GITHUB_TOKEN. Dependency bots can help you avoid manually handling the hash values of actions and promptly notify you of upstream bug fixes.

If you’re interested, I’d be happy to discuss these security risks with you.